### PR TITLE
Fix mkdir command to prevent error when directory already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function installPMD(){
 }
 
 function referencePMD(){
-  var mk = 'sudo mkdir /snap/bin && sudo chmod -R 757 /snap/bin'
+  var mk = 'sudo mkdir -p /snap/bin && sudo chmod -R 757 /snap/bin'
   var cmd = 
 `sudo echo '#! /bin/bash
 $HOME/pmd/bin/run.sh pmd "$@"' > /snap/bin/pmd`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pmd-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This action allows to use PMD Source Code Analyzer from GitHub Actions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello!

I've been using this Github action for a while to setup pmd, and it started to error today with the following message:
```
> sfdx-actions/setup-pmd@v1
Error: mkdir: cannot create directory ‘/snap/bin’: File exists
```

I think simply adding the `-p` param to the `mkdir` function should fix that issue, since it won't error if the directory already exists.

Do you have any tip about how I could test it?